### PR TITLE
Fix: catch exceptions by reference

### DIFF
--- a/src/graphlab/options/command_line_options.cpp
+++ b/src/graphlab/options/command_line_options.cpp
@@ -135,7 +135,7 @@ static const char* graph_help_string =
       }
       boost_po::store(parsed, vm);
       boost_po::notify(vm);
-    } catch( boost_po::error error) {
+    } catch(boost_po::error& error) {
       std::cout << "Invalid syntax:\n"
                 << "\t" << error.what()
                 << "\n\n" << std::endl


### PR DESCRIPTION
When I type a wrong option in command line, `boost::po` fails to replace the `%canonical_option%` tag.
For example, PowerGraph should output
```
Invalid syntax:
         unrecognised option '--threshold'
```
Instead, it outputs
```
Invalid syntax:
         unrecognised option %canonical_option%
```
The reason is that if we don't catch exceptions by reference, we get 'object slicing' which is explained [here](http://stackoverflow.com/questions/13419070/boost-program-options-exception-not-replacing-canonical-option-tag).